### PR TITLE
Stats Alias - Introducing !xp

### DIFF
--- a/src/commands/stats.js
+++ b/src/commands/stats.js
@@ -3,7 +3,8 @@ const ids = require('../megabot-internals/ids')
 
 module.exports = {
   meta: {
-    level: 0
+    level: 0,
+    alias: ['xp']
   },
   fn: (msg) => {
     const data = db.getUser(msg.author.id)


### PR DESCRIPTION
# Please check the following boxes

- [X] I've read and agree to the [Contribution Guidelines](https://github.com/Dougley/MBv2/blob/master/.github/CONTRIBUTING.md) and to the [Code of Conduct](https://github.com/Dougley/MBv2/blob/master/.github/CODE_OF_CONDUCT.md)
- [X] I've checked that I didn't commit sensitive information like tokens or other login information
- [X] I haven't hardcoded any IDs or anything else that shouldn't be (with the exception being permissions)
- [X] I tested my code and I verified it's working to the best of my ability
- [X] I checked if my code doesn't violate the styleguide with `npm test`

# Describe your pull request
Alias for the !stats, which multiple people including Azrael requested. This would be useful for mods so that they don't accidentally use Rowboat's stats for no reason.
