### PR TITLE
Increase the Dupe Confirm timeout to 30 seconds

### DIFF
--- a/src/megabot-internals/controllers/inquirer.js
+++ b/src/megabot-internals/controllers/inquirer.js
@@ -158,7 +158,7 @@ module.exports = {
           bot.removeListener('messageReactionAdd', compute)
           msg.removeReactions()
           return reject(new Error('Timed out'))
-        }, 10000)
+        }, 30000)
         if (message.id === msg.id && userid === user && emoji.id && whitelist.map(x => x.id).includes(emoji.id)) {
           clearTimeout(time)
           bot.removeListener('messageReactionAdd', compute)

--- a/src/megabot-internals/controllers/inquirer.js
+++ b/src/megabot-internals/controllers/inquirer.js
@@ -158,7 +158,7 @@ module.exports = {
           bot.removeListener('messageReactionAdd', compute)
           msg.removeReactions()
           return reject(new Error('Timed out'))
-        }, 30000)
+        }, 20000)
         if (message.id === msg.id && userid === user && emoji.id && whitelist.map(x => x.id).includes(emoji.id)) {
           clearTimeout(time)
           bot.removeListener('messageReactionAdd', compute)


### PR DESCRIPTION
The Dupe Confirm Timeout being at 10 seconds is a bit fast, let's try 30

# Please check the following boxes

- [x] I've read and agree to the [Contribution Guidelines](https://github.com/Dougley/MBv2/blob/master/.github/CONTRIBUTING.md) and to the [Code of Conduct](https://github.com/Dougley/MBv2/blob/master/.github/CODE_OF_CONDUCT.md)
- [x] I've checked that I didn't commit sensitive information like tokens or other login information
- [x] I haven't hardcoded any IDs or anything else that shouldn't be (with the exception being permissions)
- [x] I tested my code and I verified it's working to the best of my ability
- [ ] I checked if my code doesn't violate the styleguide with `npm test` - I'm only changing one number in this instance, making this stage unnecessary

# Describe your pull request

Thanks for the work so far on adding Dupe Confirmation and Undupe capabilities with #36 . I've noticed the 10 second timeout is a little fast, so maybe 30 seconds might be a bit easier for anyone who doesn't quite have lightning fast reactions.

This Pull Request changes the timeout from 10 seconds to 30 seconds on the Dupe Confirmation.