### PR TITLE
Do not nuke official comments

### DIFF
--- a/src/commands/nuke.js
+++ b/src/commands/nuke.js
@@ -59,7 +59,7 @@ const getAllComments = async (id) => {
       page: page,
       priority: 9
     })
-    await votes.push.apply(votes, data.filter(c=>!c.official))
+    await votes.push.apply(votes, data.filter(c => !c.official))
     if (data[0] && data[0].pagination.nextPage !== null) page++
     else keepGoing = false
   }

--- a/src/commands/nuke.js
+++ b/src/commands/nuke.js
@@ -59,7 +59,7 @@ const getAllComments = async (id) => {
       page: page,
       priority: 9
     })
-    await votes.push.apply(votes, data)
+    await votes.push.apply(votes, data.filter(c=>!c.official))
     if (data[0] && data[0].pagination.nextPage !== null) page++
     else keepGoing = false
   }


### PR DESCRIPTION
Security

# Please check the following boxes

- [x] I've read and agree to the [Contribution Guidelines](https://github.com/Dougley/MBv2/blob/master/.github/CONTRIBUTING.md) and to the [Code of Conduct](https://github.com/Dougley/MBv2/blob/master/.github/CODE_OF_CONDUCT.md)
- [x] I've checked that I didn't commit sensitive information like tokens or other login information
- [x] I haven't hardcoded any IDs or anything else that shouldn't be (with the exception being permissions)
- [x] I tested my code and I verified it's working to the best of my ability
- [x] I checked if my code doesn't violate the styleguide with `npm test`

# Describe your pull request

```
[10:01 PM] Blastoise186: Just imagine what chaos would happen though, if someone accidentally ran !nuke against Dan or Dabbit
[10:02 PM] Blastoise186: I would hope that the command will refuse to purge official comments
[10:03 PM] Blastoise186: If not, would you mind doing a quick PR as a safety measure?
[10:03 PM] Blastoise186: Yeah, might want that safety measure then

[10:08 PM] Blastoise186: I just think that adding a safety check to avoid nuking Official Comments is probably worth doing
[10:08 PM] Blastoise186: Or even anything that appears to have been posted by the team
[10:09 PM] Blastoise186: I'd do both, because of Dabbit
```

So yes, at least save precious data from being nuked accitentally.