### PR TITLE
utf8=✓

### DIFF
--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -22,7 +22,7 @@ const generateEmbed = (data, suffix) => {
       color: 0x008080,
       description: data.map(x => `[${x.title}](${x.htmlUrl}) - ${x.id}`).join('\n') +
         '\n\n' +
-        `[Full results](${process.env.ZENDESK_ROOT_URL}/hc/en-us/search?utf8=✓?${require('querystring').stringify({ query: suffix })})`,
+        `[Full results](${process.env.ZENDESK_ROOT_URL}/hc/en-us/search?utf8=✓&${require('querystring').stringify({ query: suffix })})`,
       footer: {
         text: `Showing the top 5 results.`
       }

--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -22,7 +22,7 @@ const generateEmbed = (data, suffix) => {
       color: 0x008080,
       description: data.map(x => `[${x.title}](${x.htmlUrl}) - ${x.id}`).join('\n') +
         '\n\n' +
-        `[Full results](${process.env.ZENDESK_ROOT_URL}/hc/en-us/search?utf8=✓&query=${require('querystring').stringify({ query: suffix })})`,
+        `[Full results](${process.env.ZENDESK_ROOT_URL}/hc/en-us/search?utf8=✓?${require('querystring').stringify({ query: suffix })})`,
       footer: {
         text: `Showing the top 5 results.`
       }

--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -22,7 +22,7 @@ const generateEmbed = (data, suffix) => {
       color: 0x008080,
       description: data.map(x => `[${x.title}](${x.htmlUrl}) - ${x.id}`).join('\n') +
         '\n\n' +
-        `[Full results](${process.env.ZENDESK_ROOT_URL}/hc/en-us/search?${require('querystring').stringify({ query: suffix })})`,
+        `[Full results](${process.env.ZENDESK_ROOT_URL}/hc/en-us/search?utf8=✓&query=${require('querystring').stringify({ query: suffix })})`,
       footer: {
         text: `Showing the top 5 results.`
       }


### PR DESCRIPTION
# Please check the following boxes

- [x] I've read and agree to the [Contribution Guidelines](https://github.com/Dougley/MBv2/blob/master/.github/CONTRIBUTING.md) and to the [Code of Conduct](https://github.com/Dougley/MBv2/blob/master/.github/CODE_OF_CONDUCT.md)
- [x] I've checked that I didn't commit sensitive information like tokens or other login information
- [x] I haven't hardcoded any IDs or anything else that shouldn't be (with the exception being permissions)
- [x] I tested my code and I verified it's working to the best of my ability
- [x] I checked if my code doesn't violate the styleguide with `npm test`

# Describe your pull request

A few days ago, I made a bug report about how the Full Results button doesn’t work on mobile. After looking at the links, I noticed that you forgot the utf8=✓ in the url. Without it, on mobile it puts `first%20second%20third` etc. in the search bar instead of `first second third` 