### PR TITLE
Make follow available to everyone

### DIFF
--- a/src/commands/follow.js
+++ b/src/commands/follow.js
@@ -2,7 +2,7 @@ const ZD = require('../megabot-internals/zendesk')
 
 module.exports = {
   meta: {
-    level: 1,
+    level: 0,
     timeout: 5,
     alias: ['subscribe']
   },


### PR DESCRIPTION
# Please check the following boxes
> All boxes are required

- [x] I agree to the [Contribution Guidelines](https://github.com/Dougley/MBv2/blob/master/.github/CONTRIBUTING.md) and to the [Code of Conduct](https://github.com/Dougley/MBv2/blob/master/.github/CODE_OF_CONDUCT.md)
- [x] I tested my code and I verified it's working to the best of my ability
- [x] I checked if my code doesn't violate the styleguide with `npm test`

# Describe your pull request
Sets the level for `follow` command to zero, so everyone can use it.

**Why is this change needed?**

I'm not sure of why it was custodian-only, but I feel like any user could benefit from it.