### PR TITLE
Added alias for cooldown

### DIFF
--- a/src/commands/cooldown.js
+++ b/src/commands/cooldown.js
@@ -4,7 +4,7 @@ const ids = require('../megabot-internals/ids')
 module.exports = {
   meta: {
     level: 0,
-    alias: ['caps']
+    alias: ['caps', 'cooldowns']
   },
   fn: (msg) => {
     const data = db.getUser(msg.author.id)


### PR DESCRIPTION
# Please check the following boxes
> All boxes are required

- [x] I agree to the [Contribution Guidelines](https://github.com/Dougley/MBv2/blob/master/.github/CONTRIBUTING.md) and to the [Code of Conduct](https://github.com/Dougley/MBv2/blob/master/.github/CODE_OF_CONDUCT.md)
- [x] I tested my code and I verified it's working to the best of my ability
- [x] I checked if my code doesn't violate the styleguide with `npm test`

# Describe your pull request

This is to add the alias for the cooldown command.

**Why is this change needed?**

There has been some confusion on the difference of the !cooldown and +cooldowns since EvilDabbit uses the plural version but MegaBot doesn't seem to do that. By adding the alias, this will help to eliminate the confusion. 

**Does your pull request solve an open issue? If yes, please mention what one**

No.
