### PR TITLE
Made the multiple dupe response a little more clear

### DIFF
--- a/src/commands/dupe.js
+++ b/src/commands/dupe.js
@@ -19,7 +19,7 @@ module.exports = {
       if (chunks.includes(target.id.toString())) return message.edit("You've included the target ID in your dupes")
       const dupes = await Promise.all(chunks.map(x => ZD.getSubmission(MB_CONSTANTS.determineID(x), ['users', 'topics'])))
       if (dupes.some(x => x.status === 'answered')) return message.edit('Some of your dupes are marked as answered, you cannot merge those')
-      if (dupes.some(x => DB.findSync('questions', { 'ids.dupe': x.id, type: 3 }))) return message.edit('Some of your dupes are already being merged')
+      if (dupes.some(x => DB.findSync('questions', { 'ids.dupe': x.id, type: 3 }))) return message.edit('One or more of your dupes have already been submitted by another Custodian')
       await message.edit({
         content: 'Is this correct?',
         ...generateEmbed(dupes, target)

--- a/src/commands/dupe.js
+++ b/src/commands/dupe.js
@@ -19,7 +19,7 @@ module.exports = {
       if (chunks.includes(target.id.toString())) return message.edit("You've included the target ID in your dupes")
       const dupes = await Promise.all(chunks.map(x => ZD.getSubmission(MB_CONSTANTS.determineID(x), ['users', 'topics'])))
       if (dupes.some(x => x.status === 'answered')) return message.edit('Some of your dupes are marked as answered, you cannot merge those')
-      if (dupes.some(x => DB.findSync('questions', { 'ids.dupe': x.id, type: 3 }))) return message.edit('One or more of your dupes have already been submitted by another Custodian')
+      if (dupes.some(x => DB.findSync('questions', { 'ids.dupe': x.id, type: 3 }))) return message.edit('One or more of your dupes have already been submitted by another Custodian. Please check the IDs and try again')
       await message.edit({
         content: 'Is this correct?',
         ...generateEmbed(dupes, target)

--- a/src/commands/dupe.js
+++ b/src/commands/dupe.js
@@ -19,7 +19,7 @@ module.exports = {
       if (chunks.includes(target.id.toString())) return message.edit("You've included the target ID in your dupes")
       const dupes = await Promise.all(chunks.map(x => ZD.getSubmission(MB_CONSTANTS.determineID(x), ['users', 'topics'])))
       if (dupes.some(x => x.status === 'answered')) return message.edit('Some of your dupes are marked as answered, you cannot merge those')
-      if (dupes.some(x => DB.findSync('questions', { 'ids.dupe': x.id, type: 3 }))) return message.edit('One or more of your dupes have already been submitted by another Custodian. Please check the IDs and try again')
+      if (dupes.some(x => DB.findSync('questions', { 'ids.dupe': x.id, type: 3 }))) return message.edit('One or more of your dupes may have been submitted by yourself or another Custodian. Please double check the IDs and try again.')
       await message.edit({
         content: 'Is this correct?',
         ...generateEmbed(dupes, target)


### PR DESCRIPTION
If one or more dupe is already been reported, i changed it to say "One or more of your dupes have already been submitted by another Custodian"

# Please check the following boxes
> All boxes are required

- [X] I agree to the [Contribution Guidelines](https://github.com/Dougley/MBv2/blob/master/.github/CONTRIBUTING.md) and to the [Code of Conduct](https://github.com/Dougley/MBv2/blob/master/.github/CODE_OF_CONDUCT.md)
- [X] I tested my code and I verified it's working to the best of my ability
- [X] I checked if my code doesn't violate the styleguide with `npm test`

# Describe your pull request

> When you have many dupes in one command, the reply if one of them was already reported was vague. I made 

**Why is this change needed?**

> In reference to an issue

**Does your pull request solve an open issue? If yes, please mention what one**

> Fixes #136 
